### PR TITLE
fix(messageinput, commenteditable): change the onKeyDown event to onKeyPress event for fixing onKeyDown event fires twice when typing in Korean and then typing enter

### DIFF
--- a/src/components/ContentEditable/ContentEditable.jsx
+++ b/src/components/ContentEditable/ContentEditable.jsx
@@ -43,11 +43,11 @@ export class ContentEditable extends Component {
     };
   };
 
-  handleKeyDown = (evt) => {
+  handleKeyPress = (evt) => {
     const {
-      props: { onKeyDown },
+      props: { onKeyPress },
     } = this;
-    onKeyDown(evt);
+    onKeyPress(evt);
   };
 
   handleInput = (evt) => {
@@ -111,7 +111,7 @@ export class ContentEditable extends Component {
     const {
         msgRef,
         handleInput,
-        handleKeyDown,
+        handleKeyPress,
         innerHTML,
         props: { placeholder, disabled, className },
       } = this,
@@ -125,7 +125,7 @@ export class ContentEditable extends Component {
         disabled={disabled}
         data-placeholder={ph}
         onInput={handleInput}
-        onKeyDown={handleKeyDown}
+        onKeyPress={handleKeyPress}
         dangerouslySetInnerHTML={innerHTML()}
       ></div>
     );
@@ -158,10 +158,10 @@ ContentEditable.propTypes = {
   onChange: PropTypes.func,
 
   /**
-   * onKeyDown handler<br>
+   * onKeyPress handler<br>
    * @param {String} value
    */
-  onKeyDown: PropTypes.func,
+  onKeyPress: PropTypes.func,
 
   /** Additional classes. */
   className: PropTypes.string,
@@ -174,7 +174,7 @@ ContentEditable.defaultProps = {
   activateAfterChange: false,
   autoFocus: false,
   onChange: () => {},
-  onKeyDown: () => {},
+  onKeyPress: () => {},
 };
 
 export default ContentEditable;

--- a/src/components/MessageInput/MessageInput.jsx
+++ b/src/components/MessageInput/MessageInput.jsx
@@ -135,7 +135,7 @@ function MessageInputInner(
     }
   };
 
-  const handleKeyDown = (evt) => {
+  const handleKeyPress = (evt) => {
     if (evt.key === "Enter" && evt.shiftKey === false) {
       evt.preventDefault();
       send();
@@ -187,7 +187,7 @@ function MessageInputInner(
             className={`${cName}__content-editor`}
             disabled={disabled}
             placeholder={ph}
-            onKeyDown={handleKeyDown}
+            onKeyPress={handleKeyPress}
             onChange={handleChange}
             activateAfterChange={activateAfterChange}
             value={stateValue}


### PR DESCRIPTION
I changed the onKeyDown event to onKeyPress event for fixing onKeyDown event fires twice when typing in Korean and then typing enter. Then it works charm.
Thank you!
It resolves #9 