### PR TITLE
Widened Firefox scroll error range to 10px

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -30,11 +30,10 @@ class MessageListInner extends React.Component {
     const list = this.containerRef.current;
 
     const topHeight = Math.round(list.scrollTop + list.clientHeight);
-    // 1 px fix for firefox
+    // 10px fix for firefox
     const sticky =
-      list.scrollHeight === topHeight ||
-      list.scrollHeight + 1 === topHeight ||
-      list.scrollHeight - 1 === topHeight;
+      list.scrollHeight + 10 >= topHeight &&
+      list.scrollHeight - 10 <= topHeight;
 
     return {
       sticky,
@@ -156,12 +155,11 @@ class MessageListInner extends React.Component {
       } else {
         if (snapshot.clientHeight < this.lastClientHeight) {
           // If was sticky because scrollHeight is not changing, so here will be equal to lastHeight plus current scrollTop
-          // 1px fix id for firefox
+          // 10px fix id for firefox
           const sHeight = list.scrollTop + this.lastClientHeight;
           if (
-            list.scrollHeight === sHeight ||
-            list.scrollHeight + 1 === sHeight ||
-            list.scrollHeight - 1 === sHeight
+            list.scrollHeight + 10 >= sHeight &&
+            list.scrollHeight - 10 <= sHeight
           ) {
             if (autoScrollToBottom === true) {
               this.scrollToEnd(this.props.scrollBehavior);


### PR DESCRIPTION
Hi @supersnager,

I believe I managed to patch the scrolling issue we were running into on Firefox with the MessageList component described [here](https://github.com/chatscope/chat-ui-kit-react/issues/42). All I did was widen the scrolling error to 10px. I thought this was reasonable because the `perfect-scrollbar` component you are using also used a 10px range:

```javascript
if (e.deltaMode && e.deltaMode === 1) {
      // Firefox in deltaMode 1: Line scrolling
      deltaX *= 10;
      deltaY *= 10;
    }
```

This is not a permanent solution, but it should suffice until you get around to overhauling the scrolling logic like you said you would.

Hope this helps,
Nick